### PR TITLE
I added a fix to get it to install correctly on OSX 10.7.x (Lion) and updated the README a little.

### DIFF
--- a/README.md
+++ b/README.md
@@ -90,7 +90,7 @@ Mac OS X:
 
 Debian/Ubuntu:
 
-    $ sudo apt-get install xulrunner-1.9-dev
+    $ sudo apt-get install xulrunner-1.9.2-dev
 
 Gentoo:
 
@@ -116,6 +116,12 @@ If you want to build with the system spidermonkey library, replace the build
 command with the following:
 
     $ python setup.py --system-library build
+
+Mac OSX 10.7.x (Lion)
+---------------------
+If you want to install python-spidermoney on a Mac running OSX 10.7.x (Lion) then you need to make sure you follow the directions above, but also make sure that you have set the ARCHFLAGS to i386 or else it might not build correctly.
+
+    $ export ARCHFLAGS="-arch i386"
 
 Examples
 ========

--- a/spidermonkey/Darwin-x86_64/jsautocfg.h
+++ b/spidermonkey/Darwin-x86_64/jsautocfg.h
@@ -1,0 +1,52 @@
+#ifndef js_cpucfg___
+#define js_cpucfg___
+
+/* AUTOMATICALLY GENERATED - DO NOT EDIT */
+
+#define IS_LITTLE_ENDIAN 1
+#undef  IS_BIG_ENDIAN
+
+#define JS_BYTES_PER_BYTE   1L
+#define JS_BYTES_PER_SHORT  2L
+#define JS_BYTES_PER_INT    4L
+#define JS_BYTES_PER_INT64  8L
+#define JS_BYTES_PER_LONG   4L
+#define JS_BYTES_PER_FLOAT  4L
+#define JS_BYTES_PER_DOUBLE 8L
+#define JS_BYTES_PER_WORD   4L
+#define JS_BYTES_PER_DWORD  8L
+
+#define JS_BITS_PER_BYTE    8L
+#define JS_BITS_PER_SHORT   16L
+#define JS_BITS_PER_INT     32L
+#define JS_BITS_PER_INT64   64L
+#define JS_BITS_PER_LONG    32L
+#define JS_BITS_PER_FLOAT   32L
+#define JS_BITS_PER_DOUBLE  64L
+#define JS_BITS_PER_WORD    32L
+
+#define JS_BITS_PER_BYTE_LOG2   3L
+#define JS_BITS_PER_SHORT_LOG2  4L
+#define JS_BITS_PER_INT_LOG2    5L
+#define JS_BITS_PER_INT64_LOG2  6L
+#define JS_BITS_PER_LONG_LOG2   5L
+#define JS_BITS_PER_FLOAT_LOG2  5L
+#define JS_BITS_PER_DOUBLE_LOG2 6L
+#define JS_BITS_PER_WORD_LOG2   5L
+
+#define JS_ALIGN_OF_SHORT   2L
+#define JS_ALIGN_OF_INT     4L
+#define JS_ALIGN_OF_LONG    4L
+#define JS_ALIGN_OF_INT64   4L
+#define JS_ALIGN_OF_FLOAT   4L
+#define JS_ALIGN_OF_DOUBLE  4L
+#define JS_ALIGN_OF_POINTER 4L
+#define JS_ALIGN_OF_WORD    4L
+
+#define JS_BYTES_PER_WORD_LOG2   2L
+#define JS_BYTES_PER_DWORD_LOG2  3L
+#define JS_WORDS_PER_DWORD_LOG2  1L
+
+#define JS_STACK_GROWTH_DIRECTION (-1)
+
+#endif /* js_cpucfg___ */

--- a/spidermonkey/Darwin-x86_64/jsautokw.h
+++ b/spidermonkey/Darwin-x86_64/jsautokw.h
@@ -1,0 +1,401 @@
+    /*
+     * Generating switch for the list of 61 entries:
+     * break
+     * case
+     * continue
+     * default
+     * delete
+     * do
+     * else
+     * export
+     * false
+     * for
+     * function
+     * if
+     * in
+     * new
+     * null
+     * return
+     * switch
+     * this
+     * true
+     * typeof
+     * var
+     * void
+     * while
+     * with
+     * const
+     * try
+     * catch
+     * finally
+     * throw
+     * instanceof
+     * abstract
+     * boolean
+     * byte
+     * char
+     * class
+     * double
+     * extends
+     * final
+     * float
+     * goto
+     * implements
+     * import
+     * int
+     * interface
+     * long
+     * native
+     * package
+     * private
+     * protected
+     * public
+     * short
+     * static
+     * super
+     * synchronized
+     * throws
+     * transient
+     * volatile
+     * enum
+     * debugger
+     * yield
+     * let
+     */
+    switch (JSKW_LENGTH()) {
+      case 2:
+        if (JSKW_AT(0) == 'd') {
+            if (JSKW_AT(1)=='o') {
+                JSKW_GOT_MATCH(5) /* do */
+            }
+            JSKW_NO_MATCH()
+        }
+        if (JSKW_AT(0) == 'i') {
+            if (JSKW_AT(1) == 'f') {
+                JSKW_GOT_MATCH(11) /* if */
+            }
+            if (JSKW_AT(1) == 'n') {
+                JSKW_GOT_MATCH(12) /* in */
+            }
+            JSKW_NO_MATCH()
+        }
+        JSKW_NO_MATCH()
+      case 3:
+        switch (JSKW_AT(2)) {
+          case 'r':
+            if (JSKW_AT(0) == 'f') {
+                if (JSKW_AT(1)=='o') {
+                    JSKW_GOT_MATCH(9) /* for */
+                }
+                JSKW_NO_MATCH()
+            }
+            if (JSKW_AT(0) == 'v') {
+                if (JSKW_AT(1)=='a') {
+                    JSKW_GOT_MATCH(20) /* var */
+                }
+                JSKW_NO_MATCH()
+            }
+            JSKW_NO_MATCH()
+          case 't':
+            if (JSKW_AT(0) == 'i') {
+                if (JSKW_AT(1)=='n') {
+                    JSKW_GOT_MATCH(42) /* int */
+                }
+                JSKW_NO_MATCH()
+            }
+            if (JSKW_AT(0) == 'l') {
+                if (JSKW_AT(1)=='e') {
+                    JSKW_GOT_MATCH(60) /* let */
+                }
+                JSKW_NO_MATCH()
+            }
+            JSKW_NO_MATCH()
+          case 'w':
+            if (JSKW_AT(0)=='n' && JSKW_AT(1)=='e') {
+                JSKW_GOT_MATCH(13) /* new */
+            }
+            JSKW_NO_MATCH()
+          case 'y':
+            if (JSKW_AT(0)=='t' && JSKW_AT(1)=='r') {
+                JSKW_GOT_MATCH(25) /* try */
+            }
+            JSKW_NO_MATCH()
+        }
+        JSKW_NO_MATCH()
+      case 4:
+        switch (JSKW_AT(3)) {
+          case 'd':
+            if (JSKW_AT(0)=='v' && JSKW_AT(1)=='o' && JSKW_AT(2)=='i') {
+                JSKW_GOT_MATCH(21) /* void */
+            }
+            JSKW_NO_MATCH()
+          case 'e':
+            if (JSKW_AT(2) == 's') {
+                if (JSKW_AT(0) == 'c') {
+                    if (JSKW_AT(1)=='a') {
+                        JSKW_GOT_MATCH(1) /* case */
+                    }
+                    JSKW_NO_MATCH()
+                }
+                if (JSKW_AT(0) == 'e') {
+                    if (JSKW_AT(1)=='l') {
+                        JSKW_GOT_MATCH(6) /* else */
+                    }
+                    JSKW_NO_MATCH()
+                }
+                JSKW_NO_MATCH()
+            }
+            if (JSKW_AT(2) == 't') {
+                if (JSKW_AT(0)=='b' && JSKW_AT(1)=='y') {
+                    JSKW_GOT_MATCH(32) /* byte */
+                }
+                JSKW_NO_MATCH()
+            }
+            if (JSKW_AT(2) == 'u') {
+                if (JSKW_AT(0)=='t' && JSKW_AT(1)=='r') {
+                    JSKW_GOT_MATCH(18) /* true */
+                }
+                JSKW_NO_MATCH()
+            }
+            JSKW_NO_MATCH()
+          case 'g':
+            if (JSKW_AT(0)=='l' && JSKW_AT(1)=='o' && JSKW_AT(2)=='n') {
+                JSKW_GOT_MATCH(44) /* long */
+            }
+            JSKW_NO_MATCH()
+          case 'h':
+            if (JSKW_AT(0)=='w' && JSKW_AT(1)=='i' && JSKW_AT(2)=='t') {
+                JSKW_GOT_MATCH(23) /* with */
+            }
+            JSKW_NO_MATCH()
+          case 'l':
+            if (JSKW_AT(0)=='n' && JSKW_AT(1)=='u' && JSKW_AT(2)=='l') {
+                JSKW_GOT_MATCH(14) /* null */
+            }
+            JSKW_NO_MATCH()
+          case 'm':
+            if (JSKW_AT(0)=='e' && JSKW_AT(1)=='n' && JSKW_AT(2)=='u') {
+                JSKW_GOT_MATCH(57) /* enum */
+            }
+            JSKW_NO_MATCH()
+          case 'o':
+            if (JSKW_AT(0)=='g' && JSKW_AT(1)=='o' && JSKW_AT(2)=='t') {
+                JSKW_GOT_MATCH(39) /* goto */
+            }
+            JSKW_NO_MATCH()
+          case 'r':
+            if (JSKW_AT(0)=='c' && JSKW_AT(1)=='h' && JSKW_AT(2)=='a') {
+                JSKW_GOT_MATCH(33) /* char */
+            }
+            JSKW_NO_MATCH()
+          case 's':
+            if (JSKW_AT(0)=='t' && JSKW_AT(1)=='h' && JSKW_AT(2)=='i') {
+                JSKW_GOT_MATCH(17) /* this */
+            }
+            JSKW_NO_MATCH()
+        }
+        JSKW_NO_MATCH()
+      case 5:
+        switch (JSKW_AT(3)) {
+          case 'a':
+            if (JSKW_AT(0) == 'b') {
+                if (JSKW_AT(4)=='k' && JSKW_AT(1)=='r' && JSKW_AT(2)=='e') {
+                    JSKW_GOT_MATCH(0) /* break */
+                }
+                JSKW_NO_MATCH()
+            }
+            if (JSKW_AT(0) == 'f') {
+                if (JSKW_AT(4) == 'l') {
+                    if (JSKW_AT(2)=='n' && JSKW_AT(1)=='i') {
+                        JSKW_GOT_MATCH(37) /* final */
+                    }
+                    JSKW_NO_MATCH()
+                }
+                if (JSKW_AT(4) == 't') {
+                    if (JSKW_AT(2)=='o' && JSKW_AT(1)=='l') {
+                        JSKW_GOT_MATCH(38) /* float */
+                    }
+                    JSKW_NO_MATCH()
+                }
+                JSKW_NO_MATCH()
+            }
+            JSKW_NO_MATCH()
+          case 'c':
+            if (JSKW_AT(0)=='c' && JSKW_AT(1)=='a' && JSKW_AT(2)=='t' && JSKW_AT(4)=='h') {
+                JSKW_GOT_MATCH(26) /* catch */
+            }
+            JSKW_NO_MATCH()
+          case 'e':
+            if (JSKW_AT(0)=='s' && JSKW_AT(1)=='u' && JSKW_AT(2)=='p' && JSKW_AT(4)=='r') {
+                JSKW_GOT_MATCH(52) /* super */
+            }
+            JSKW_NO_MATCH()
+          case 'l':
+            if (JSKW_AT(0) == 'w') {
+                if (JSKW_AT(4)=='e' && JSKW_AT(1)=='h' && JSKW_AT(2)=='i') {
+                    JSKW_GOT_MATCH(22) /* while */
+                }
+                JSKW_NO_MATCH()
+            }
+            if (JSKW_AT(0) == 'y') {
+                if (JSKW_AT(4)=='d' && JSKW_AT(1)=='i' && JSKW_AT(2)=='e') {
+                    JSKW_GOT_MATCH(59) /* yield */
+                }
+                JSKW_NO_MATCH()
+            }
+            JSKW_NO_MATCH()
+          case 'o':
+            if (JSKW_AT(0)=='t' && JSKW_AT(1)=='h' && JSKW_AT(2)=='r' && JSKW_AT(4)=='w') {
+                JSKW_GOT_MATCH(28) /* throw */
+            }
+            JSKW_NO_MATCH()
+          case 'r':
+            if (JSKW_AT(0)=='s' && JSKW_AT(1)=='h' && JSKW_AT(2)=='o' && JSKW_AT(4)=='t') {
+                JSKW_GOT_MATCH(50) /* short */
+            }
+            JSKW_NO_MATCH()
+          case 's':
+            if (JSKW_AT(0) == 'c') {
+                if (JSKW_AT(4) == 's') {
+                    if (JSKW_AT(2)=='a' && JSKW_AT(1)=='l') {
+                        JSKW_GOT_MATCH(34) /* class */
+                    }
+                    JSKW_NO_MATCH()
+                }
+                if (JSKW_AT(4) == 't') {
+                    if (JSKW_AT(2)=='n' && JSKW_AT(1)=='o') {
+                        JSKW_GOT_MATCH(24) /* const */
+                    }
+                    JSKW_NO_MATCH()
+                }
+                JSKW_NO_MATCH()
+            }
+            if (JSKW_AT(0) == 'f') {
+                if (JSKW_AT(4)=='e' && JSKW_AT(1)=='a' && JSKW_AT(2)=='l') {
+                    JSKW_GOT_MATCH(8) /* false */
+                }
+                JSKW_NO_MATCH()
+            }
+            JSKW_NO_MATCH()
+        }
+        JSKW_NO_MATCH()
+      case 6:
+        switch (JSKW_AT(0)) {
+          case 'd':
+            if (JSKW_AT(1) == 'o') {
+                if (JSKW_AT(5)=='e' && JSKW_AT(4)=='l' && JSKW_AT(2)=='u' && JSKW_AT(3)=='b') {
+                    JSKW_GOT_MATCH(35) /* double */
+                }
+                JSKW_NO_MATCH()
+            }
+            if (JSKW_AT(1) == 'e') {
+                if (JSKW_AT(5)=='e' && JSKW_AT(4)=='t' && JSKW_AT(2)=='l' && JSKW_AT(3)=='e') {
+                    JSKW_GOT_MATCH(4) /* delete */
+                }
+                JSKW_NO_MATCH()
+            }
+            JSKW_NO_MATCH()
+          case 'e':
+            JSKW_TEST_GUESS(7) /* export */
+          case 'i':
+            JSKW_TEST_GUESS(41) /* import */
+          case 'n':
+            JSKW_TEST_GUESS(45) /* native */
+          case 'p':
+            JSKW_TEST_GUESS(49) /* public */
+          case 'r':
+            JSKW_TEST_GUESS(15) /* return */
+          case 's':
+            if (JSKW_AT(1) == 't') {
+                if (JSKW_AT(5)=='c' && JSKW_AT(4)=='i' && JSKW_AT(2)=='a' && JSKW_AT(3)=='t') {
+                    JSKW_GOT_MATCH(51) /* static */
+                }
+                JSKW_NO_MATCH()
+            }
+            if (JSKW_AT(1) == 'w') {
+                if (JSKW_AT(5)=='h' && JSKW_AT(4)=='c' && JSKW_AT(2)=='i' && JSKW_AT(3)=='t') {
+                    JSKW_GOT_MATCH(16) /* switch */
+                }
+                JSKW_NO_MATCH()
+            }
+            JSKW_NO_MATCH()
+          case 't':
+            if (JSKW_AT(5) == 'f') {
+                if (JSKW_AT(4)=='o' && JSKW_AT(1)=='y' && JSKW_AT(2)=='p' && JSKW_AT(3)=='e') {
+                    JSKW_GOT_MATCH(19) /* typeof */
+                }
+                JSKW_NO_MATCH()
+            }
+            if (JSKW_AT(5) == 's') {
+                if (JSKW_AT(4)=='w' && JSKW_AT(1)=='h' && JSKW_AT(2)=='r' && JSKW_AT(3)=='o') {
+                    JSKW_GOT_MATCH(54) /* throws */
+                }
+                JSKW_NO_MATCH()
+            }
+            JSKW_NO_MATCH()
+        }
+        JSKW_NO_MATCH()
+      case 7:
+        switch (JSKW_AT(0)) {
+          case 'b':
+            JSKW_TEST_GUESS(31) /* boolean */
+          case 'd':
+            JSKW_TEST_GUESS(3) /* default */
+          case 'e':
+            JSKW_TEST_GUESS(36) /* extends */
+          case 'f':
+            JSKW_TEST_GUESS(27) /* finally */
+          case 'p':
+            if (JSKW_AT(1) == 'a') {
+                JSKW_TEST_GUESS(46) /* package */
+            }
+            if (JSKW_AT(1) == 'r') {
+                JSKW_TEST_GUESS(47) /* private */
+            }
+            JSKW_NO_MATCH()
+        }
+        JSKW_NO_MATCH()
+      case 8:
+        switch (JSKW_AT(4)) {
+          case 'g':
+            JSKW_TEST_GUESS(58) /* debugger */
+          case 'i':
+            JSKW_TEST_GUESS(2) /* continue */
+          case 'r':
+            JSKW_TEST_GUESS(30) /* abstract */
+          case 't':
+            if (JSKW_AT(1) == 'o') {
+                JSKW_TEST_GUESS(56) /* volatile */
+            }
+            if (JSKW_AT(1) == 'u') {
+                JSKW_TEST_GUESS(10) /* function */
+            }
+            JSKW_NO_MATCH()
+        }
+        JSKW_NO_MATCH()
+      case 9:
+        if (JSKW_AT(1) == 'n') {
+            JSKW_TEST_GUESS(43) /* interface */
+        }
+        if (JSKW_AT(1) == 'r') {
+            if (JSKW_AT(0) == 'p') {
+                JSKW_TEST_GUESS(48) /* protected */
+            }
+            if (JSKW_AT(0) == 't') {
+                JSKW_TEST_GUESS(55) /* transient */
+            }
+            JSKW_NO_MATCH()
+        }
+        JSKW_NO_MATCH()
+      case 10:
+        if (JSKW_AT(1) == 'n') {
+            JSKW_TEST_GUESS(29) /* instanceof */
+        }
+        if (JSKW_AT(1) == 'm') {
+            JSKW_TEST_GUESS(40) /* implements */
+        }
+        JSKW_NO_MATCH()
+      case 12:
+        JSKW_TEST_GUESS(53) /* synchronized */
+    }
+    JSKW_NO_MATCH()


### PR DESCRIPTION
I added a fix to get it to install correctly on OSX 10.7.x (Lion) and updated the README a little. For Lion the machine name is x86_64 so it wasn't picking up the files under Darwin-i386 that is needed.

I added a section to the README.md to let people know to set the ARCHFLAGS correctly, and also updated an ubuntu package name that was incorrect. 
