### PR TITLE
sort input files

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -182,7 +182,7 @@ setup(
     ext_modules =  [
         Extension(
             "spidermonkey",
-            sources=find_sources(),
+            sources=sorted(find_sources()),
             **platform_config()
         )
     ],


### PR DESCRIPTION
when building packages (e.g. for openSUSE Linux)
(random) filesystem order of input files
influences ordering of functions in the output,
thus without the patch, builds (in disposable VMs) would differ.

See https://reproducible-builds.org/ for why this matters.